### PR TITLE
Add basic chat feature

### DIFF
--- a/Quasar.Client/Controls/InputBox.cs
+++ b/Quasar.Client/Controls/InputBox.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace Quasar.Client.Controls
+{
+    public static class InputBox
+    {
+        public static DialogResult Show(string title, string promptText, ref string value)
+        {
+            DialogResult dialogResult = DialogResult.Cancel;
+            using (var form = new Form())
+            {
+                Label label = new Label();
+                TextBox textBox = new TextBox();
+                Button buttonOk = new Button();
+                Button buttonCancel = new Button();
+
+                form.Text = title;
+                label.Text = promptText;
+                textBox.Text = value;
+
+                buttonOk.Text = "OK";
+                buttonCancel.Text = "Cancel";
+                buttonOk.DialogResult = DialogResult.OK;
+                buttonCancel.DialogResult = DialogResult.Cancel;
+
+                label.SetBounds(9, 20, 372, 13);
+                textBox.SetBounds(12, 36, 372, 20);
+                buttonOk.SetBounds(228, 72, 75, 23);
+                buttonCancel.SetBounds(309, 72, 75, 23);
+
+                label.AutoSize = true;
+                textBox.Anchor = textBox.Anchor | AnchorStyles.Right;
+                buttonOk.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+                buttonCancel.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+
+                form.ClientSize = new Size(396, 107);
+                form.Controls.AddRange(new Control[] { label, textBox, buttonOk, buttonCancel });
+                form.ClientSize = new Size(Math.Max(300, label.Right + 10), form.ClientSize.Height);
+                form.FormBorderStyle = FormBorderStyle.FixedDialog;
+                form.StartPosition = FormStartPosition.CenterScreen;
+                form.MinimizeBox = false;
+                form.MaximizeBox = false;
+                form.AcceptButton = buttonOk;
+                form.CancelButton = buttonCancel;
+
+                dialogResult = form.ShowDialog();
+                value = textBox.Text;
+            }
+            return dialogResult;
+        }
+    }
+}

--- a/Quasar.Client/Messages/ChatHandler.cs
+++ b/Quasar.Client/Messages/ChatHandler.cs
@@ -1,0 +1,44 @@
+using Quasar.Client.Controls;
+using Quasar.Client.Networking;
+using Quasar.Common.Messages;
+using Quasar.Common.Networking;
+using System.Windows.Forms;
+
+namespace Quasar.Client.Messages
+{
+    /// <summary>
+    /// Handles chat messages from the server and sends user responses.
+    /// </summary>
+    public class ChatHandler : IMessageProcessor
+    {
+        private readonly QuasarClient _client;
+
+        public ChatHandler(QuasarClient client)
+        {
+            _client = client;
+        }
+
+        public bool CanExecute(IMessage message) => message is ChatMessage chat && !chat.FromClient;
+
+        public bool CanExecuteFrom(ISender sender) => true;
+
+        public void Execute(ISender sender, IMessage message)
+        {
+            switch (message)
+            {
+                case ChatMessage chat:
+                    Execute(sender, chat);
+                    break;
+            }
+        }
+
+        private void Execute(ISender client, ChatMessage message)
+        {
+            string response = string.Empty;
+            if (InputBox.Show("Administrator", message.Text, ref response) == DialogResult.OK && !string.IsNullOrEmpty(response))
+            {
+                _client.Send(new ChatMessage { FromClient = true, Text = response });
+            }
+        }
+    }
+}

--- a/Quasar.Client/QuasarApplication.cs
+++ b/Quasar.Client/QuasarApplication.cs
@@ -189,6 +189,7 @@ namespace Quasar.Client
             _messageProcessors.Add(new FileManagerHandler(client));
             _messageProcessors.Add(new KeyloggerHandler());
             _messageProcessors.Add(new MessageBoxHandler());
+            _messageProcessors.Add(new ChatHandler(client));
             _messageProcessors.Add(new PasswordRecoveryHandler());
             _messageProcessors.Add(new RegistryHandler());
             _messageProcessors.Add(new RemoteDesktopHandler());

--- a/Quasar.Common/Messages/ChatMessage.cs
+++ b/Quasar.Common/Messages/ChatMessage.cs
@@ -1,0 +1,14 @@
+using ProtoBuf;
+
+namespace Quasar.Common.Messages
+{
+    [ProtoContract]
+    public class ChatMessage : IMessage
+    {
+        [ProtoMember(1)]
+        public bool FromClient { get; set; }
+
+        [ProtoMember(2)]
+        public string Text { get; set; }
+    }
+}

--- a/Quasar.Server/Forms/FrmChat.Designer.cs
+++ b/Quasar.Server/Forms/FrmChat.Designer.cs
@@ -1,0 +1,91 @@
+namespace Quasar.Server.Forms
+{
+    partial class FrmChat
+    {
+        private System.ComponentModel.IContainer components = null;
+        private System.Windows.Forms.TextBox txtChatInput;
+        private System.Windows.Forms.RichTextBox txtChatOutput;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            this.txtChatOutput = new System.Windows.Forms.RichTextBox();
+            this.txtChatInput = new System.Windows.Forms.TextBox();
+            this.tableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
+            this.tableLayoutPanel.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // txtChatOutput
+            // 
+            this.txtChatOutput.BackColor = System.Drawing.Color.Black;
+            this.txtChatOutput.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.txtChatOutput.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.txtChatOutput.Font = new System.Drawing.Font("Consolas", 9F);
+            this.txtChatOutput.ForeColor = System.Drawing.Color.WhiteSmoke;
+            this.txtChatOutput.Location = new System.Drawing.Point(3, 3);
+            this.txtChatOutput.Name = "txtChatOutput";
+            this.txtChatOutput.ReadOnly = true;
+            this.txtChatOutput.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.Vertical;
+            this.txtChatOutput.Size = new System.Drawing.Size(631, 297);
+            this.txtChatOutput.TabIndex = 1;
+            this.txtChatOutput.Text = "";
+            this.txtChatOutput.TextChanged += new System.EventHandler(this.txtChatOutput_TextChanged);
+            // 
+            // txtChatInput
+            // 
+            this.txtChatInput.BackColor = System.Drawing.Color.Black;
+            this.txtChatInput.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.txtChatInput.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.txtChatInput.Font = new System.Drawing.Font("Consolas", 9.75F);
+            this.txtChatInput.ForeColor = System.Drawing.Color.WhiteSmoke;
+            this.txtChatInput.Location = new System.Drawing.Point(3, 306);
+            this.txtChatInput.MaxLength = 200;
+            this.txtChatInput.Name = "txtChatInput";
+            this.txtChatInput.Size = new System.Drawing.Size(631, 16);
+            this.txtChatInput.TabIndex = 0;
+            this.txtChatInput.KeyDown += new System.Windows.Forms.KeyEventHandler(this.txtChatInput_KeyDown);
+            // 
+            // tableLayoutPanel
+            // 
+            this.tableLayoutPanel.BackColor = System.Drawing.Color.Black;
+            this.tableLayoutPanel.ColumnCount = 1;
+            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel.Controls.Add(this.txtChatOutput, 0, 0);
+            this.tableLayoutPanel.Controls.Add(this.txtChatInput, 0, 1);
+            this.tableLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanel.Name = "tableLayoutPanel";
+            this.tableLayoutPanel.RowCount = 2;
+            this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel.Size = new System.Drawing.Size(637, 323);
+            this.tableLayoutPanel.TabIndex = 2;
+            // 
+            // FrmChat
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+            this.ClientSize = new System.Drawing.Size(637, 323);
+            this.Controls.Add(this.tableLayoutPanel);
+            this.Font = new System.Drawing.Font("Segoe UI", 8.25F);
+            this.Name = "FrmChat";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "Chat []";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FrmChat_FormClosing);
+            this.Load += new System.EventHandler(this.FrmChat_Load);
+            this.tableLayoutPanel.ResumeLayout(false);
+            this.tableLayoutPanel.PerformLayout();
+            this.ResumeLayout(false);
+
+        }
+    }
+}

--- a/Quasar.Server/Forms/FrmChat.cs
+++ b/Quasar.Server/Forms/FrmChat.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Windows.Forms;
+using Quasar.Server.Helper;
+using Quasar.Server.Messages;
+using Quasar.Server.Networking;
+
+namespace Quasar.Server.Forms
+{
+    public partial class FrmChat : Form
+    {
+        private readonly Client _connectClient;
+        public readonly ChatHandler ChatHandler;
+        private static readonly Dictionary<Client, FrmChat> OpenedForms = new Dictionary<Client, FrmChat>();
+
+        public static FrmChat CreateNewOrGetExisting(Client client)
+        {
+            if (OpenedForms.ContainsKey(client))
+            {
+                return OpenedForms[client];
+            }
+            FrmChat f = new FrmChat(client);
+            f.Disposed += (sender, args) => OpenedForms.Remove(client);
+            OpenedForms.Add(client, f);
+            return f;
+        }
+
+        public FrmChat(Client client)
+        {
+            _connectClient = client;
+            ChatHandler = new ChatHandler(client);
+
+            RegisterMessageHandler();
+            InitializeComponent();
+        }
+
+        private void RegisterMessageHandler()
+        {
+            _connectClient.ClientState += ClientDisconnected;
+            ChatHandler.ProgressChanged += ChatOutput;
+            MessageHandler.Register(ChatHandler);
+        }
+
+        private void UnregisterMessageHandler()
+        {
+            MessageHandler.Unregister(ChatHandler);
+            ChatHandler.ProgressChanged -= ChatOutput;
+            _connectClient.ClientState -= ClientDisconnected;
+        }
+
+        private void ChatOutput(object sender, string text)
+        {
+            txtChatOutput.AppendText($"Client: {text}{Environment.NewLine}");
+        }
+
+        private void ClientDisconnected(Client client, bool connected)
+        {
+            if (!connected)
+            {
+                Invoke((MethodInvoker)Close);
+            }
+        }
+
+        private void FrmChat_Load(object sender, EventArgs e)
+        {
+            Text = WindowHelper.GetWindowTitle("Chat", _connectClient);
+        }
+
+        private void FrmChat_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            UnregisterMessageHandler();
+        }
+
+        private void txtChatInput_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Enter && !string.IsNullOrWhiteSpace(txtChatInput.Text))
+            {
+                ChatHandler.SendMessage(txtChatInput.Text.Trim());
+                txtChatOutput.AppendText($"Admin: {txtChatInput.Text.Trim()}{Environment.NewLine}");
+                txtChatInput.Clear();
+                e.Handled = true;
+                e.SuppressKeyPress = true;
+            }
+        }
+
+        private void txtChatOutput_TextChanged(object sender, EventArgs e)
+        {
+            NativeMethodsHelper.ScrollToBottom(txtChatOutput.Handle);
+        }
+    }
+}

--- a/Quasar.Server/Forms/FrmChat.resx
+++ b/Quasar.Server/Forms/FrmChat.resx
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Quasar.Server/Forms/FrmMain.Designer.cs
+++ b/Quasar.Server/Forms/FrmMain.Designer.cs
@@ -293,6 +293,7 @@ namespace Quasar.Server.Forms
             // 
             this.userSupportToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.showMessageboxToolStripMenuItem,
+            this.remoteChatToolStripMenuItem,
             this.remoteDesktopToolStripMenuItem,
             this.visitWebsiteToolStripMenuItem});
             this.userSupportToolStripMenuItem.Image = global::Quasar.Server.Properties.Resources.user;
@@ -307,9 +308,17 @@ namespace Quasar.Server.Forms
             this.showMessageboxToolStripMenuItem.Size = new System.Drawing.Size(171, 22);
             this.showMessageboxToolStripMenuItem.Text = "Show Messagebox";
             this.showMessageboxToolStripMenuItem.Click += new System.EventHandler(this.showMessageboxToolStripMenuItem_Click);
-            // 
+            //
+            // remoteChatToolStripMenuItem
+            //
+            this.remoteChatToolStripMenuItem.Image = global::Quasar.Server.Properties.Resources.information;
+            this.remoteChatToolStripMenuItem.Name = "remoteChatToolStripMenuItem";
+            this.remoteChatToolStripMenuItem.Size = new System.Drawing.Size(171, 22);
+            this.remoteChatToolStripMenuItem.Text = "Chat";
+            this.remoteChatToolStripMenuItem.Click += new System.EventHandler(this.remoteChatToolStripMenuItem_Click);
+            //
             // remoteDesktopToolStripMenuItem
-            // 
+            //
             this.remoteDesktopToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("remoteDesktopToolStripMenuItem.Image")));
             this.remoteDesktopToolStripMenuItem.Name = "remoteDesktopToolStripMenuItem";
             this.remoteDesktopToolStripMenuItem.Size = new System.Drawing.Size(171, 22);
@@ -885,6 +894,7 @@ namespace Quasar.Server.Forms
         private System.Windows.Forms.ToolStripMenuItem userSupportToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem showMessageboxToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem visitWebsiteToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem remoteChatToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem remoteExecuteToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem localFileToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem webFileToolStripMenuItem;

--- a/Quasar.Server/Forms/FrmMain.cs
+++ b/Quasar.Server/Forms/FrmMain.cs
@@ -648,6 +648,16 @@ namespace Quasar.Server.Forms
             }
         }
 
+        private void remoteChatToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            foreach (Client c in GetSelectedClients())
+            {
+                FrmChat frmChat = FrmChat.CreateNewOrGetExisting(c);
+                frmChat.Show();
+                frmChat.Focus();
+            }
+        }
+
         private void passwordRecoveryToolStripMenuItem_Click(object sender, EventArgs e)
         {
             Client[] clients = GetSelectedClients();

--- a/Quasar.Server/Messages/ChatHandler.cs
+++ b/Quasar.Server/Messages/ChatHandler.cs
@@ -1,0 +1,40 @@
+using Quasar.Common.Messages;
+using Quasar.Common.Networking;
+using Quasar.Server.Networking;
+
+namespace Quasar.Server.Messages
+{
+    /// <summary>
+    /// Handles messages for the chat communication with a client.
+    /// </summary>
+    public class ChatHandler : MessageProcessorBase<string>
+    {
+        private readonly Client _client;
+
+        public ChatHandler(Client client) : base(true)
+        {
+            _client = client;
+        }
+
+        public override bool CanExecute(IMessage message) => message is ChatMessage;
+
+        public override bool CanExecuteFrom(ISender sender) => _client.Equals(sender);
+
+        public override void Execute(ISender sender, IMessage message)
+        {
+            if (message is ChatMessage chat && chat.FromClient)
+            {
+                OnReport(chat.Text);
+            }
+        }
+
+        /// <summary>
+        /// Sends a chat message to the client.
+        /// </summary>
+        /// <param name="text">The message text.</param>
+        public void SendMessage(string text)
+        {
+            _client.Send(new ChatMessage { FromClient = false, Text = text });
+        }
+    }
+}

--- a/Quasar.Server/Quasar.Server.csproj
+++ b/Quasar.Server/Quasar.Server.csproj
@@ -154,6 +154,12 @@
     <Compile Update="Forms\FrmRemoteShell.Designer.cs">
       <DependentUpon>FrmRemoteShell.cs</DependentUpon>
     </Compile>
+    <Compile Update="Forms\FrmChat.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\FrmChat.Designer.cs">
+      <DependentUpon>FrmChat.cs</DependentUpon>
+    </Compile>
     <Compile Update="Forms\FrmReverseProxy.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -251,6 +257,9 @@
     </EmbeddedResource>
     <EmbeddedResource Update="Forms\FrmRemoteShell.resx">
       <DependentUpon>FrmRemoteShell.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Forms\FrmChat.resx">
+      <DependentUpon>FrmChat.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Update="Forms\FrmReverseProxy.resx">
       <DependentUpon>FrmReverseProxy.cs</DependentUpon>


### PR DESCRIPTION
## Summary
- introduce `ChatMessage` protobuf
- add client and server chat handlers
- add client input box helper
- implement `FrmChat` form on server
- wire chat into server menu and client message processors

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841131e55448329a9df5399aacf8150